### PR TITLE
Fixed OPDS basic auth for android Coolreader

### DIFF
--- a/opds_catalog/middleware.py
+++ b/opds_catalog/middleware.py
@@ -34,12 +34,18 @@ class BasicAuthMiddleware(object):
             authentication = request.META[self.header]
         except KeyError:
             return self.unauthed()  
-                    
-        (auth_meth, auth_data) = authentication.split(' ',1)
+
+        try:
+           (auth_meth, auth_data) = authentication.split(' ',1)
+        except:
+           auth_meth="basic"
+           auth_data=authentication
+
         if 'basic' != auth_meth.lower():
             return self.unauthed()
         auth_data = base64.b64decode(auth_data.strip()).decode('utf-8')
         username, password = auth_data.split(':',1)            
+
 
         user = auth.authenticate(username=username, password=password)
         if user and user.is_active:


### PR DESCRIPTION
The following issue from this forum thread is still actual fo me  4 years after:
 http://www.sopds.ru/index.php/forum/razdel-predlozhenij/421-ne-avtorizuet-v-soopds-iz-coolreader

I've bumped into this issue using latest sopds from git and Coolreader from the google play market.

Looks like issue is that Coolreader does not send "Basic" keyword before actuatal base64 credentials.
I've compared data that browser sends and what Coolreader sends - and they end up in **authentication** = request.META  differently.
In browser  it is like    authentication = "Basic   AaaAaAaaBase64EncodedCreds"
With coolreader it is just  authentication =  "AaaAaAaaBase64EncodedCreds".

This causes 500 error with    (auth_meth, auth_data) = authentication.split(' ',1)    line in middlware.py not able to split the string.

Fix that  I suggest enabled auth  Coolreader, and it does not break regular auth for me.
----------------------

Вот эта проблема  4хлетней давности с форума все еще похоже актуальна:
 http://www.sopds.ru/index.php/forum/razdel-predlozhenij/421-ne-avtorizuet-v-soopds-iz-coolreader

Я  воспроизвел ее с обычным Coolreaderом из гугломаркета и sopds из гита, на совершенно чистой новой машине.  Суть в том, что Coolreader шлет только base64 строку с логином и паролем, а слово Basic не шлет.  Фикс который я предлагаю - порешал для меня это проблему.

